### PR TITLE
Fix for crash when trying to load Blitz file on Mac OS X

### DIFF
--- a/src/installer.cpp
+++ b/src/installer.cpp
@@ -255,6 +255,7 @@ BarInfo InstallNet::blitzCheck(QString name)
             barInfo.name = "BAD";
         }
     }
+    return barInfo;
 }
 
 void InstallNet::install(QList<QUrl> files)


### PR DESCRIPTION
I've tested this fix on 10.10 Yosemite.
