### PR TITLE
Fix building with a Qt 5.5 snapshot

### DIFF
--- a/src/fs/fs.h
+++ b/src/fs/fs.h
@@ -19,6 +19,7 @@
 
 #include <QFile>
 #include <QIODevice>
+#include <QDataStream>
 #include <QDir>
 #include <QDebug>
 #include <QDesktopServices>


### PR DESCRIPTION
There was a header cleanup prior to the 5.5 release, and QDataStream is
no longer included from unrelated headers.