### PR TITLE
Download to save dir instead of work dir

### DIFF
--- a/src/downloadinfo.h
+++ b/src/downloadinfo.h
@@ -299,7 +299,7 @@ public:
     }
 
     void setApps(QList<Apps*> newApps, QString& version) {
-        baseDir = QDir::currentPath() + "/" + version;
+        baseDir = getSaveDir() + "/" + version;
 
         // Check which apps user wanted
         foreach (Apps* newApp, newApps) {

--- a/src/ports.cpp
+++ b/src/ports.cpp
@@ -116,7 +116,7 @@ QString getSaveDir() {
     if (QFileInfo(writable).isWritable())
         return writable;
 
-    return QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);
+    return QStandardPaths::writableLocation(QStandardPaths::DownloadLocation);
 #endif
 }
 

--- a/src/search/mainnet.cpp
+++ b/src/search/mainnet.cpp
@@ -533,7 +533,7 @@ void MainNet::showFirmwareData(QByteArray data, QString variant)
 
                 // No need to check OS and Radio as they are variable
                 if (app->type() == "application") {
-                    bool exists = QFile(QDir::currentPath() + "/" + _versionRelease + "/" + app->name()).size() == app->size();
+                    bool exists = QFile(getSaveDir() + "/" + _versionRelease + "/" + app->name()).size() == app->size();
                     app->setIsAvailable(!exists);
                 }
                 app->setIsMarked(app->isAvailable() && !app->isInstalled());


### PR DESCRIPTION
Currently, Sachesi downloads to the current directory. If the
current directory is not writable, it keeps re-downloading.
Instead, download to directory returned by getSaveDir.

In getSaveDir, change DesktopLocation to DownloadLocation.

Might be useful to also use save dir as a default for
settings.backupFolder and settings.installFolder.