### PR TITLE
Ubuntu fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,33 @@
 # Qt
 *.user
 *.qm
+
+# Compiler Stuff
+/Makefile
+/Sachesi
+/moc_apps.cpp
+/moc_apps.cpp
+/moc_autoloaderwriter.cpp
+/moc_backupinfo.cpp
+/moc_blitzinfo.cpp
+/moc_boot.cpp
+/moc_carrierinfo.cpp
+/moc_deviceinfo.cpp
+/moc_discoveredrelease.cpp
+/moc_downloadinfo.cpp
+/moc_fs.cpp
+/moc_ifs.cpp
+/moc_installer.cpp
+/moc_mainnet.cpp
+/moc_qnx6.cpp
+/moc_quagzipfile.cpp
+/moc_quaziodevice.cpp
+/moc_quazipfile.cpp
+/moc_rcfs.cpp
+/moc_scanner.cpp
+/moc_splitter.cpp
+/moc_translator.cpp
+/qrc_UI.cpp
+/qrc_translations.cpp
+
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Sachesi
-=======
+# Sachesi
 
 Introducing Sachesi. The results of my continued work on firmware tools for Blackberry 10 and Playbook.
 
@@ -10,8 +9,8 @@ The application mimics communications performed by official Blackberry tools and
 
 Developed by Sacha Refshauge. Project originally known as Dingleberry. Public release of source code on May 26, 2014.
 
-Build Instructions
-==================
+
+## Build Instructions
 
 Technically should work on all operating systems that support Qt. This project works with both dynamic and static builds of Qt4.8+ and Qt5.0+.
 It is known to build and has built binaries available for desktop platforms: Windows XP+, Linux, Mac OSX 10.5+. It can also build and run a restricted subset of activities on mobile platforms: Symbian, Android and Blackberry 10. To upgrade firmware via a mobile device requires USB low-level access (host device must support network usb drivers), such as Symbian and possibly rooted Android devices.
@@ -20,4 +19,48 @@ This project requires miniLZO, zlib-1.2.8, QuaZIP and OpenSSL.
 For Linux and Mac, the project optionally uses libusb-1.0 for bootloader activities.
 For your convenience, a snapshot of the important files from libusb-1.0, miniLZO, zlib-1.2.8 and QuaZIP have been provided. OpenSSL for Android is also provided.
 
-On Windows, you will need to install OpenSSL to C:\openssl
+
+## Windows Build Instructions (MinGW)
+
+1. Install latest QT with MinGW from [qt-project.org](https://qt-project.org).
+2. Install OpenSSL to `C:\OpenSSL` from [http://www.wittfella.com/openssl](http://www.wittfella.com/openssl).
+3. Open Sachesi.pro in QtCreator.
+4. Adjust the hardcoded paths set in `QML.qrc` to point to the correct qml files.
+5. Run.
+
+**Notes for Visual Studio**:
+
+- Use [this precompiled OpenSSL](http://www.npcglib.org/~stathis/blog/precompiled-openssl) version.
+
+
+## Ubuntu Build Instructions
+
+1. Install the required dependencies:
+
+```bash
+sudo apt-get install qt5-qmake libqt5network5 libqt5qml5 qtdeclarative5-settings-plugin qtdeclarative5-controls-plugin qtdeclarative5-dialogs-plugin qtdeclarative5-quicklayouts-plugin qtdeclarative5-window-plugin qtdeclarative5-qtquick2-plugin qttools5-dev-tools libssl-dev qtdeclarative5-dev libusb-1.0-0-dev
+```
+
+2. Compile Sachesi:
+
+```bash
+cd /path/to/Sachesi;
+qmake;
+make -j4;
+```
+
+**Common Errors**
+
+On some systems there might be some `Cannot find file translations/...` errors. This can
+be fixed by executing `make compiler_lang_make_all` and executing the above steps again.
+
+
+## OSX Build Instructions
+
+1. Install latest XCode.
+2. Install latest QT from [qt-project.org](https://qt-project.org).
+3. Install `brew` from [brew.sh](https://brew.sh).
+4. Run `brew install libusb`.
+5. Open Sachesi.pro in QtCreator.
+6. Run.
+

--- a/translations.qrc
+++ b/translations.qrc
@@ -1,11 +1,11 @@
 <RCC>
-    <qresource prefix="/">
-        <file>translations/English.qm</file>
-        <file>translations/Russian.qm</file>
-        <file>translations/French.qm</file>
-        <file>translations/Spanish.qm</file>
-        <file>translations/German.qm</file>
-        <file>translations/Dutch.qm</file>
-        <file>translations/Chinese.qm</file>
+    <qresource>
+        <file>translations/English.ts</file>
+        <file>translations/Russian.ts</file>
+        <file>translations/French.ts</file>
+        <file>translations/Spanish.ts</file>
+        <file>translations/German.ts</file>
+        <file>translations/Dutch.ts</file>
+        <file>translations/Chinese.ts</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
Hey there,

these were the required fixes for me to get the repository in a clean state.


**Changes**
- `translations.qrc` now uses relative paths to `ts` files, it was the _false_ path to `qm` before (see #91 )
- `README.md` was polished, has now complete compile instructions with actually complete dependencies. Migrated everything from the outdated wiki, so it's easier to find for others.
- `.gitignore` file contains now all meta source files (that were auto-generated) and binaries that don't need to be tracked via git.

